### PR TITLE
fix container token refresh

### DIFF
--- a/src/main/perl/lib/Amazon/Credentials.pm.in
+++ b/src/main/perl/lib/Amazon/Credentials.pm.in
@@ -588,7 +588,7 @@ sub refresh_token {
   my $self = shift;
   my $creds;
   
-  if ( $self->get_role && $self->get_role eq 'ECS' ) {
+  if ( $self->get_container && $self->get_container eq 'ECS' ) {
     $creds = $self->get_creds_from_container;
    }
   elsif ( $self->get_role ) {


### PR DESCRIPTION
should check `container` property at here.

refs. https://github.com/rlauer6/perl-Amazon-Credentials/blob/Release-1.0.10-1/src/main/perl/lib/Amazon/Credentials.pm.in#L636-L637