### PR TITLE
Possible fix for fetching AWS creds from ENV Vars

### DIFF
--- a/src/main/perl/lib/Amazon/Credentials.pm.in
+++ b/src/main/perl/lib/Amazon/Credentials.pm.in
@@ -373,7 +373,7 @@ sub get_creds_from_env {
     = qw{ AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN };
 
   if ( $ENV{'AWS_ACCESS_KEY_ID'} && $ENV{'AWS_SECRET_ACCESS_KEY'} ) {
-    @{$creds}{@cred_keys} = ( 'ENV', @env_keys );
+    @{$creds}{@cred_keys} = ( 'ENV', @ENV{@env_keys} );
   }
 
   return $creds;


### PR DESCRIPTION
I'm less familiar with creating perl libs on cpan, but fetching Credentials from env vars broke a few months ago. This change seems to correct the error.

Without my fix, the example at [test-aws-credentials.pl](https://github.com/rlauer6/perl-Amazon-Credentials/blob/master/src/examples/test-aws-credentials.pl) returns the env key names rather than the values. With the fix, the proper credentials are returned. 